### PR TITLE
Simplify Camera implementation

### DIFF
--- a/oresat_star_tracker/camera.py
+++ b/oresat_star_tracker/camera.py
@@ -1,7 +1,5 @@
 """Star tracker AR013x camera"""
 
-import io
-import os
 from enum import Enum
 from pathlib import Path
 import cv2
@@ -31,45 +29,20 @@ class Camera:
     MAX_ROWS = 960
     PIXEL_BYTES = MAX_COLS * MAX_ROWS
 
-    def __init__(self, mock: bool = False):
-        self._mock = mock
-        self._state = CameraState.LOCKOUT
-        self._image_size = (self.MAX_COLS, self.MAX_ROWS)
-        self._mock_data = np.zeros((self.MAX_COLS, self.MAX_ROWS, 3), dtype=np.uint8)
-
-        if self._mock:
-            self._state = CameraState.RUNNING
-            return
-
+    def __init__(self):
         if not self.CAPTURE_PATH.exists():
+            self._image_size = (self.MAX_COLS, self.MAX_ROWS)
             self._state = CameraState.NOT_FOUND
             logger.error("Could not find capture path")
             return
 
         # no errors; attempt to read image
+        context_path = Path("/sys/devices/platform/prucam/context_settings")
+        x_size = int((context_path / "x_size").read_text())
+        y_size = int((context_path / "y_size").read_text())
+        self._image_size = (y_size, x_size)
         self._state = CameraState.RUNNING
-        self._image_size = self.read_image_size()
         logger.info("Camera is unlocked")
-
-    def read_image_size(self):
-        """Read dimensions of image from the camera"""
-        if self._state != CameraState.RUNNING:
-            raise CameraError(f"Camera error; state is {self._state}")
-        if self._mock:
-            return self._image_size
-        x_size = self.read_context_setting("x_size")
-        y_size = self.read_context_setting("y_size")
-        return (y_size, x_size)
-
-    def read_context_setting(self, name: str) -> int:
-        """'Read a context setting."""
-        if self._state != CameraState.RUNNING:
-            raise CameraError(f"Camera error; state is {self._state}")
-        context_path = "/sys/devices/platform/prucam/context_settings"
-        with open(f"{context_path}/{name}", "r") as f:
-            value = int(f.read())
-            return value
-        # path check
 
     def capture(self, color: bool = True) -> np.ndarray:
         """Capture an image
@@ -93,28 +66,24 @@ class Camera:
         if self._state != CameraState.RUNNING:
             raise CameraError(f"Camera error; state is {self._state}")
 
-        if self._mock:
-            return self._mock_data
-        # Read raw data
-        capture_path = str(self.CAPTURE_PATH)
-        fd = os.open(capture_path, os.O_RDWR)
-        fio = io.FileIO(fd, closefd=False)
-        imgbuf = bytearray(self._image_size[0] * self._image_size[1])
-        fio.readinto(imgbuf)
-        fio.close()
-        os.close(fd)
-
-        # Convert to image
-        img = np.frombuffer(imgbuf, dtype=np.uint8).reshape(
-            self._image_size[0], self._image_size[1]
-        )
+        img = np.fromfile(self.CAPTURE_PATH, dtype=(np.uint8, self._image_size), count=1)[0]
 
         # Convert to color
         if color is True:
             return cv2.cvtColor(img, cv2.COLOR_BayerBG2BGR)
-
         return img
 
     @property
     def state(self) -> CameraState:
         return self._state
+
+
+class MockCamera(Camera):
+    def __init__(self):
+        self._mock_data = np.zeros((self.MAX_COLS, self.MAX_ROWS, 3), dtype=np.uint8)
+        self._state = CameraState.RUNNING
+
+    def capture(self, color: bool = True) -> np.ndarray:
+        if self._state != CameraState.RUNNING:
+            raise CameraError(f"Camera error; state is {self._state}")
+        return self._mock_data

--- a/oresat_star_tracker/star_tracker_service.py
+++ b/oresat_star_tracker/star_tracker_service.py
@@ -10,7 +10,7 @@ import numpy as np
 import tifffile as tiff
 from olaf import Service, logger, new_oresat_file  # , set_cpufreq_gov
 
-from .camera import Camera, CameraError, CameraState
+from .camera import Camera, CameraError, CameraState, MockCamera
 
 
 class State(IntEnum):
@@ -43,15 +43,15 @@ class StarTrackerService(Service):
     def __init__(self, mock_hw: bool = False):
         super().__init__()
 
-        self.mock_hw = mock_hw
         self._state = State.BOOT
 
-        if self.mock_hw:
-            logger.debug("mocking camera")
-        else:
+        if not mock_hw:
             logger.debug("not mocking camera")
+            self._camera = Camera()
+        else:
+            logger.debug("mocking camera")
+            self._camera = MockCamera()
 
-        self._camera = Camera(self.mock_hw)
         self._last_capture = None
 
     def on_start(self):


### PR DESCRIPTION
Building on the previous commit which removes the module loading dance, this simplifies a bunch more of the implementation:
 - Pulls out MockCamera into its own class so that all the methods aren't dual purpose on `_mock`.
- Uses the appropriate file handling tools from Path and numpy. This has the added benefit of no longer copying the acquired image three times, which should be faster.