### PR TITLE
Extract quaternion from LOST and update OD records

### DIFF
--- a/oresat_star_tracker/star_tracker_service.py
+++ b/oresat_star_tracker/star_tracker_service.py
@@ -191,7 +191,7 @@ class StarTrackerService(Service):
             logger.info(f"changing status: {self._state.name} -> {State.STANDBY.name}")
             self._state = State.STANDBY
         else:
-            self.sleep(self._capture_delay_obj.value)
+            self.sleep_ms(self._capture_delay_obj.value)
 
     def _capture_only_mode(self):
         """Use camera for some amount of time."""

--- a/oresat_star_tracker/star_tracker_service.py
+++ b/oresat_star_tracker/star_tracker_service.py
@@ -6,7 +6,8 @@ from time import monotonic, time
 from PIL import Image
 import numpy as np
 import tifffile as tiff
-from olaf import Service, logger, new_oresat_file  # , set_cpufreq_gov
+import json
+from olaf import Service, logger, new_oresat_file, Node
 from oresat_star_tracker.lost.wrapper import estimate
 
 from .camera import Camera, CameraError, CameraState, MockCamera
@@ -38,6 +39,8 @@ STATE_TRANSISTIONS = {
 
 class StarTrackerService(Service):
     """Star Tracker service."""
+
+    node: Node
 
     def __init__(self, mock_hw: bool = False):
         super().__init__()
@@ -176,7 +179,7 @@ class StarTrackerService(Service):
 
         # NOTE: Lost currently writes the capture to disk temporarily
         attitude_estimate = estimate(data)
-        logger.info(attitude_estimate)
+        logger.debug(json.dumps(attitude_estimate, indent=4))
 
         self._attitude_i_obj.value = attitude_estimate["attitude_i"]
         self._attitude_j_obj.value = attitude_estimate["attitude_j"]
@@ -199,6 +202,7 @@ class StarTrackerService(Service):
             self._state = State.STANDBY
         else:
             self.sleep_ms(self._capture_delay_obj.value)
+            logger.debug(f"sleeping for {self._capture_delay_obj.value}")
 
     def _capture_only_mode(self):
         """Use camera for some amount of time."""
@@ -227,7 +231,6 @@ class StarTrackerService(Service):
             self._last_capture_time.value = int(ts)
             self._last_capture = data
             img_count += 1
-            logger.info(f"capture {img_count}")
 
             if self._save_obj.value:
                 self._save_to_cache("img", self._encode_compress_tiff(data))  # Save image

--- a/oresat_star_tracker/star_tracker_service.py
+++ b/oresat_star_tracker/star_tracker_service.py
@@ -54,14 +54,16 @@ class StarTrackerService(Service):
         self._last_capture = None
 
     def on_start(self):
-        """Save references to OD objiables"""
+        """Save references to OD"""
 
         self.status_obj = self.node.od["status"]
 
         orientation_rec = self.node.od["orientation"]
-        self._right_ascension_obj = orientation_rec["right_ascension"]
-        self._declination_obj = orientation_rec["declination"]
-        self._orientation_obj = orientation_rec["roll"]
+        self._attitude_i_obj = orientation_rec["attitude_i"]
+        self._attitude_j_obj = orientation_rec["attitude_j"]
+        self._attitude_k_obj = orientation_rec["attitude_k"]
+        self._attitude_real_obj = orientation_rec["attitude_real"]
+        self._attitude_known_obj = orientation_rec["attitude_known"]
         self._time_stamp_obj = orientation_rec["time_since_midnight"]
 
         capture_rec = self.node.od["capture"]
@@ -90,9 +92,11 @@ class StarTrackerService(Service):
     def on_stop(self):
         """When service stops clear star tracking data."""
 
-        self._right_ascension_obj.value = 0
-        self._declination_obj.value = 0
-        self._orientation_obj.value = 0
+        self._attitude_i_obj = 0
+        self._attitude_j_obj = 0
+        self._attitude_k_obj = 0
+        self._attitude_real_obj = 0
+        self._attitude_known_obj = 0
         self._time_stamp_obj.value = 0
         self._last_capture = None
         self._last_capture_time.value = 0
@@ -171,18 +175,20 @@ class StarTrackerService(Service):
             return
 
         # NOTE: Lost currently writes the capture to disk temporarily
-        lost_args = lost.identify_args(algo="tetra")
-        lost_data = lost.identify(data, lost_args)
+        attitude_estimate = lost.identify(data)
 
-        self._right_ascension_obj.value = int(lost_data["attitude_ra"])
-        self._declination_obj.value = int(lost_data["attitude_de"])
-        self._orientation_obj.value = int(lost_data["attitude_roll"])
+        self._attitude_i_obj = attitude_estimate["attitude_i"]
+        self._attitude_j_obj = attitude_estimate["attitude_j"]
+        self._attitude_k_obj = attitude_estimate["attitude_k"]
+        self._attitude_real_obj = attitude_estimate["attitude_real"]
+        self._attitude_known_obj = attitude_estimate["attitude_known"]
 
         self._time_stamp_obj.value = int(ts)
         self._last_capture_time.value = int(ts)
         self._last_capture = data
 
         # Send the star tracker data TPDOs
+        # TODO: This will need to change with the CAN configs
         self.node.send_tpdo(3)
         self.node.send_tpdo(4)
 

--- a/oresat_star_tracker/star_tracker_service.py
+++ b/oresat_star_tracker/star_tracker_service.py
@@ -4,10 +4,10 @@ from enum import IntEnum
 from io import BytesIO
 from time import monotonic, time
 from PIL import Image
-import lost
 import numpy as np
 import tifffile as tiff
 from olaf import Service, logger, new_oresat_file  # , set_cpufreq_gov
+from oresat_star_tracker.lost.wrapper import estimate
 
 from .camera import Camera, CameraError, CameraState, MockCamera
 
@@ -175,22 +175,23 @@ class StarTrackerService(Service):
             return
 
         # NOTE: Lost currently writes the capture to disk temporarily
-        attitude_estimate = lost.identify(data)
+        attitude_estimate = estimate(data)
+        logger.info(attitude_estimate)
 
-        self._attitude_i_obj = attitude_estimate["attitude_i"]
-        self._attitude_j_obj = attitude_estimate["attitude_j"]
-        self._attitude_k_obj = attitude_estimate["attitude_k"]
-        self._attitude_real_obj = attitude_estimate["attitude_real"]
-        self._attitude_known_obj = attitude_estimate["attitude_known"]
+        self._attitude_i_obj.value = attitude_estimate["attitude_i"]
+        self._attitude_j_obj.value = attitude_estimate["attitude_j"]
+        self._attitude_k_obj.value = attitude_estimate["attitude_k"]
+        self._attitude_real_obj.value = attitude_estimate["attitude_real"]
+        self._attitude_known_obj.value = attitude_estimate["attitude_known"]
 
         self._time_stamp_obj.value = int(ts)
         self._last_capture_time.value = int(ts)
         self._last_capture = data
 
         # Send the star tracker data TPDOs
-        # TODO: This will need to change with the CAN configs
         self.node.send_tpdo(3)
         self.node.send_tpdo(4)
+        self.node.send_tpdo(5)
 
         # If the frequency is 0, star track once
         if self._capture_delay_obj.value == 0:


### PR DESCRIPTION
This is a very small commit. It updates the way that data is extracted from LOST and updates the OD records(?) to send new data over the CAN bus. This change is blocked by [oresat-configs/55](https://github.com/oresat/oresat-configs/issues/55)