### PR TITLE
Camera refactor again

### DIFF
--- a/oresat_star_tracker/camera.py
+++ b/oresat_star_tracker/camera.py
@@ -22,22 +22,31 @@ class CameraError(Exception):
 class Camera:
     """Star tracker AR013x camera"""
 
-    # these files are provided by the prucam-dkms debian package
+    cap_dev = Path("/dev/prucam")
 
-    CAPTURE_PATH = Path("/dev/prucam")
-    CONTEXT_PATH = Path("/sys/devices/platform/prudev/context_settings")
-    MAX_COLS = 1280
-    MAX_ROWS = 960
-    PIXEL_BYTES = MAX_COLS * MAX_ROWS
+    # defaults to the resolution of the AR013x image sensor
+    x_size = 1280
+    y_size = 960
+
+    # assumes one pixel corresponds to one byte
+    n_pixels = x_size * y_size
 
     def __init__(self):
-        if not self.CAPTURE_PATH.exists():
+        if not self.cap_dev.exists():
             self._state = CameraState.NOT_FOUND
-            logger.error("Could not find capture path")
+            logger.error("Could not find capture device")
             return
 
         self._state = CameraState.RUNNING
         logger.info("Camera is unlocked")
+
+        # read camera paramaters from sysfs
+        dev_ctx = Path("/sys/devices/platform/prudev/context_settings")
+        self.x_size = int((dev_ctx / "x_size").read_text())
+        self.y_size = int((dev_ctx / "y_size").read_text())
+        self.n_pixels = self.x_size * self.y_size
+
+        logger.debug(f"Camera resolution is {self.x_size}x{self.y_size}")
 
     def capture(self) -> np.ndarray:
         """Capture an image
@@ -63,10 +72,10 @@ class Camera:
         return np.clip(rgb * 255, 0, 255).astype(np.uint8)
 
     def _read_raw(self) -> np.ndarray:
-        with open(self.CAPTURE_PATH, 'rb') as cam:
-            data = cam.read(self.PIXEL_BYTES)
+        with open(self.cap_dev, 'rb') as cam:
+            data = cam.read(self.n_pixels)
 
-        return np.frombuffer(data, np.uint8).reshape(self.MAX_ROWS, self.MAX_COLS)
+        return np.frombuffer(data, np.uint8).reshape(self.x_size, self.y_size)
 
     def _demosaic(self, raw: np.ndarray) -> np.ndarray:
         raw = raw.astype(np.float32) / 255

--- a/oresat_star_tracker/camera.py
+++ b/oresat_star_tracker/camera.py
@@ -25,22 +25,17 @@ class Camera:
     # these files are provided by the prucam-dkms debian package
 
     CAPTURE_PATH = Path("/dev/prucam")
+    CONTEXT_PATH = Path("/sys/devices/platform/prudev/context_settings")
     MAX_COLS = 1280
     MAX_ROWS = 960
     PIXEL_BYTES = MAX_COLS * MAX_ROWS
 
     def __init__(self):
         if not self.CAPTURE_PATH.exists():
-            self._image_size = (self.MAX_COLS, self.MAX_ROWS)
             self._state = CameraState.NOT_FOUND
             logger.error("Could not find capture path")
             return
 
-        # no errors; attempt to read image
-        context_path = Path("/sys/devices/platform/prudev/context_settings")
-        x_size = int((context_path / "x_size").read_text())
-        y_size = int((context_path / "y_size").read_text())
-        self._image_size = (y_size, x_size)
         self._state = CameraState.RUNNING
         logger.info("Camera is unlocked")
 
@@ -60,17 +55,22 @@ class Camera:
 
         if self._state != CameraState.RUNNING:
             raise CameraError(f"Camera error; state is {self._state}")
+        logger.info("capturing image")
 
-        raw = np.fromfile(self.CAPTURE_PATH, dtype=(np.uint8, self._image_size), count=1)[0]
-
-        # normalize, demosaicing expects float
-        raw = raw.astype(np.float32) / 255
-
-        # demosaicing, reconstruct full color
-        # image from samples overlaid with a bayer filter
-        rgb = demosaicing_CFA_Bayer_Malvar2004(raw)
+        raw = self._read_raw()
+        rgb = self._demosaic(raw)
 
         return np.clip(rgb * 255, 0, 255).astype(np.uint8)
+
+    def _read_raw(self) -> np.ndarray:
+        with open(self.CAPTURE_PATH, 'rb') as cam:
+            data = cam.read(self.PIXEL_BYTES)
+
+        return np.frombuffer(data, np.uint8).reshape(self.MAX_ROWS, self.MAX_COLS)
+
+    def _demosaic(self, raw: np.ndarray) -> np.ndarray:
+        raw = raw.astype(np.float32) / 255
+        return demosaicing_CFA_Bayer_Malvar2004(raw)
 
     @property
     def state(self) -> CameraState:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,19 @@
+from PIL import Image
+import numpy as np
+from pathlib import Path
+
+capture_path = Path('/dev/prucam')
+
+print(capture_path.stat())
+
+try:
+    print('capturing')
+    raw = np.fromfile(capture_path, dtype=(np.uint8, 1280 * 960), count=1)[0]
+except Exception as e:
+    print(f'Error reading from file {e}')
+
+with open(capture_path, 'rb') as f:
+    raw = np.frombuffer(f.read(960 * 1280), np.uint8).reshape(960, 1280)
+
+    img = Image.fromarray(raw)
+    img.save('test.png')


### PR DESCRIPTION
`np.fromfile` does not work for our current implementation of the prucam dev. It requires `fseek` and `ftell` to be implemented.

I have broken the capture routine into two smaller functions.