### PR TITLE
Use trusted publishing, Uuse dependency groups for dev

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,20 +2,20 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ "published" ]
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: '3.x'
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -24,9 +24,5 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Clone oresat-star-tracker repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[dev]
+          python -m pip install . --group dev
 
       - name: Check format with Ruff
         run: ruff format --check --diff .
@@ -34,7 +34,7 @@ jobs:
         run: ruff check
 
       - name: Typecheck with mypy
-        run: mypy oresat_star_tracker
+        run: mypy oresat_star_tracker tests
 
       - name: Test building pypi package
         run: python -m build

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ will only work on the custom OreSat Star Tracker board. See the
 Install Python dependenies
 
 ```bash
-$ pip3 install -e .[dev]
+$ pip3 install -e . --group dev
 ```
 
 Make a virtual CAN bus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ dependencies = [
     "numpy",
     "pillow",
     "colour-demosaicing",
-    "oresat-olaf>=3.6.5",
+    "oresat-olaf==3.6.5",
     "tifffile",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "build >= 1.3.0",
     "mypy >= 1.18.2",


### PR DESCRIPTION
This gets the star tracker in line with the latest oresat python packaging standards. I've fixed OLAF to 3.6.5 for now since 3.7 brings in a new oresat-configs that changes the OD definitions. That'll have to wait for further changes.